### PR TITLE
Update FastFollow.lua

### DIFF
--- a/FastFollow.lua
+++ b/FastFollow.lua
@@ -59,7 +59,7 @@ casting = nil
 cast_time = 0
 pause_delay = 0.1
 pause_dismount_delay = 0.5
-pauseon = S{'spell','item','dismount'}
+pauseon = S{}
 co = nil
 tracking = false
 


### PR DESCRIPTION
the pauseon feature messes with gearswap, and is generally not useful. I think by default it should be off, since everyday people go on the Windower discord trying to figure out why their gearswap doesn't work, and it's so often fastfollow.